### PR TITLE
Refresh history button does not become enable when we edit a linearization #92

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/config/ObjectMapperConfiguration.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/config/ObjectMapperConfiguration.java
@@ -24,6 +24,7 @@ import edu.stanford.protege.webprotege.tag.EntityTagsChangedEvent;
 import edu.stanford.protege.webprotege.tag.ProjectTagsChangedEvent;
 import edu.stanford.protege.webprotege.watches.WatchAddedEvent;
 import edu.stanford.protege.webprotege.watches.WatchRemovedEvent;
+import edu.stanford.protege.webprotegeeventshistory.config.events.ProjectLinearizationChangedEvent;
 import org.semanticweb.owlapi.model.*;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -313,6 +314,7 @@ public class ObjectMapperConfiguration {
                     OntologyBrowserTextChangedEvent.class,
                     PermissionsChangedEvent.class,
                     ProjectChangedEvent.class,
+                    ProjectLinearizationChangedEvent.class,
                     ProjectMovedToTrashEvent.class,
                     OntologyChangedEvent.class,
                     ProjectRemovedFromTrashEvent.class,

--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/config/events/ProjectLinearizationChangedEvent.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/config/events/ProjectLinearizationChangedEvent.java
@@ -1,0 +1,23 @@
+package edu.stanford.protege.webprotegeeventshistory.config.events;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import edu.stanford.protege.webprotege.common.*;
+
+@JsonTypeName(ProjectLinearizationChangedEvent.CHANNEL)
+public record ProjectLinearizationChangedEvent(EventId eventId,
+                                               ProjectId projectId) implements ProjectEvent {
+    public static final String CHANNEL = "webprotege.linearization.ProjectLinearizationChangedEvent";
+
+    public String getChannel() {
+        return CHANNEL;
+    }
+
+    public EventId eventId() {
+        return this.eventId;
+    }
+
+    public ProjectId projectId() {
+        return this.projectId;
+    }
+
+}


### PR DESCRIPTION
fix for https://github.com/who-icatx/icatx-project/issues/92