### PR TITLE
Add history filtering

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/GetProjectChangesForHistoryViewCommandHandler.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/GetProjectChangesForHistoryViewCommandHandler.java
@@ -33,7 +33,7 @@ public class GetProjectChangesForHistoryViewCommandHandler implements CommandHan
     public Mono<ProjectChangesForHistoryViewResponse> handleRequest(ProjectChangesForHistoryViewRequest request, ExecutionContext executionContext) {
         int pageNumber = request.pageRequest().getPageNumber();
         int pageSize = request.pageRequest().getPageSize();
-        var changes = service.fetchPaginatedProjectChanges(request.projectId(), request.subject(), pageNumber, pageSize);
+        var changes = service.fetchPaginatedProjectChanges(request.projectId(), request.subject(), pageNumber, pageSize, request.filter());
         return Mono.just(ProjectChangesForHistoryViewResponse.create(changes));
     }
 }

--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/ProjectChangesForHistoryViewRequest.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/ProjectChangesForHistoryViewRequest.java
@@ -13,7 +13,8 @@ import static edu.stanford.protege.webprotegeeventshistory.uiHistoryConcern.hand
 public record ProjectChangesForHistoryViewRequest(
         @JsonProperty("projectId") ProjectId projectId,
         @JsonProperty("subject") Optional<OWLEntity> subject,
-        @JsonProperty("pageRequest") PageRequest pageRequest
+        @JsonProperty("pageRequest") PageRequest pageRequest,
+        @JsonProperty("filter") String filter
 ) implements ProjectRequest<ProjectChangesForHistoryViewResponse> {
 
     public final static String CHANNEL = "webprotege.events.projects.history.ProjectChangesForHistory";

--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventService.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventService.java
@@ -12,7 +12,7 @@ public interface NewRevisionsEventService {
 
     void registerEvent(NewRevisionsEvent newLinRevEvent);
 
-    Page<ProjectChange> fetchPaginatedProjectChanges(ProjectId projectId, Optional<OWLEntity> subject, int pageNumber, int pageSize);
+    Page<ProjectChange> fetchPaginatedProjectChanges(ProjectId projectId, Optional<OWLEntity> subject, int pageNumber, int pageSize, String filter);
 
     ChangedEntities getChangedEntitiesAfterTimestamp(ProjectId projectId, long timestamp);
 

--- a/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventServiceImpl.java
+++ b/src/main/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventServiceImpl.java
@@ -12,6 +12,7 @@ import edu.stanford.protege.webprotegeeventshistory.uiHistoryConcern.events.Revi
 import edu.stanford.protege.webprotegeeventshistory.uiHistoryConcern.mappers.ProjectChangeMapper;
 import edu.stanford.protege.webprotegeeventshistory.uiHistoryConcern.mappers.RevisionEventMapper;
 import edu.stanford.protege.webprotegeeventshistory.uiHistoryConcern.repositories.RevisionsEventRepository;
+import org.bson.Document;
 import org.semanticweb.owlapi.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,8 @@ public class NewRevisionsEventServiceImpl implements NewRevisionsEventService {
     }
 
     @Override
-    public Page<ProjectChange> fetchPaginatedProjectChanges(ProjectId projectId, Optional<OWLEntity> subject, int pageNumber, int pageSize) {
+    public Page<ProjectChange> fetchPaginatedProjectChanges(ProjectId projectId, Optional<OWLEntity> subject, int pageNumber, int pageSize, String filter) {
+        LOGGER.warn("Fetching changes with filter: {}", filter);
         String entityIriSubject = subject.map(sub -> sub.getIRI().toString()).orElse(null);
         RevisionsEvent probe = RevisionsEvent.create(
                 projectId,
@@ -69,7 +71,7 @@ public class NewRevisionsEventServiceImpl implements NewRevisionsEventService {
                 null,
                 null,
                 0,
-                null,
+                new Document("summary", filter),
                 null
         );
         ExampleMatcher matcher = ExampleMatcher.matching()
@@ -78,6 +80,7 @@ public class NewRevisionsEventServiceImpl implements NewRevisionsEventService {
                 .withMatcher(WHOFIC_ENTITY_IRI, ExampleMatcher.GenericPropertyMatchers.exact())
                 .withIgnorePaths(CHANGE_TYPE)
                 .withIgnorePaths(ENTITY_TYPE)
+                .withMatcher("projectChange.summary", m -> m.contains().ignoreCase())
                 .withIgnoreNullValues();
 
         Example<RevisionsEvent> example = Example.of(probe, matcher);

--- a/src/test/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/GetProjectChangesForHistoryViewCommandHandlerIntegrationTest.java
+++ b/src/test/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/handlers/GetProjectChangesForHistoryViewCommandHandlerIntegrationTest.java
@@ -51,7 +51,7 @@ public class GetProjectChangesForHistoryViewCommandHandlerIntegrationTest {
         ProjectId projectId = ProjectId.generate();
         OWLEntity subject = mockOWLEntity("http://example.com/Entity1");
         PageRequest pageRequest = PageRequest.requestPageWithSize(1, 10);
-        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.of(subject), pageRequest);
+        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.of(subject), pageRequest, "");
 
         ProjectChange pc1 = insertMockRevisionsEvent(projectId, "http://example.com/Entity1", 12345L);
         ProjectChange pc2 = insertMockRevisionsEvent(projectId, "http://example.com/Entity1", 12346L);
@@ -73,7 +73,7 @@ public class GetProjectChangesForHistoryViewCommandHandlerIntegrationTest {
     public void GIVEN_validRequestWithoutSubject_WHEN_handleRequestCalled_THEN_returnAllProjectChanges() {
         ProjectId projectId = ProjectId.generate();
         PageRequest pageRequest = PageRequest.requestPageWithSize(1, 10);
-        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest);
+        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest, "");
 
         ProjectChange pc1 = insertMockRevisionsEvent(projectId, "http://example.com/Entity1", 12345L);
         ProjectChange pc2 = insertMockRevisionsEvent(projectId, "http://example.com/Entity1", 12346L);
@@ -96,7 +96,7 @@ public class GetProjectChangesForHistoryViewCommandHandlerIntegrationTest {
     public void GIVEN_emptyProject_WHEN_handleRequestCalled_THEN_returnEmptyPage() {
         ProjectId projectId = ProjectId.generate();
         PageRequest pageRequest = PageRequest.requestPageWithSize(1, 10);
-        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest);
+        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest, "");
 
 
         Mono<ProjectChangesForHistoryViewResponse> responseMono = commandHandler.handleRequest(request, null);
@@ -111,7 +111,7 @@ public class GetProjectChangesForHistoryViewCommandHandlerIntegrationTest {
     public void GIVEN_requestWithPagination_WHEN_handleRequestCalled_THEN_returnPaginatedResults() {
         ProjectId projectId = ProjectId.generate();
         PageRequest pageRequest = PageRequest.requestPageWithSize(1, 1);
-        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest);
+        ProjectChangesForHistoryViewRequest request = new ProjectChangesForHistoryViewRequest(projectId, Optional.empty(), pageRequest, "");
 
         insertMockRevisionsEvent(projectId, "http://example.com/Entity1", 12345L);
         insertMockRevisionsEvent(projectId, "http://example.com/Entity2", 12346L);

--- a/src/test/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventServiceTest.java
+++ b/src/test/java/edu/stanford/protege/webprotegeeventshistory/uiHistoryConcern/services/NewRevisionsEventServiceTest.java
@@ -82,7 +82,7 @@ public class NewRevisionsEventServiceTest {
         ProjectChange mockProjectChange = mock(ProjectChange.class);
         when(projectChangeMapper.mapProjectChangeDocumentToProjectChange(any())).thenReturn(mockProjectChange);
 
-        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.of(mockEntity), 1, 1);
+        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.of(mockEntity), 1, 1, "");
 
         assertNotNull(result);
         assertEquals(1, result.getPageElements().size());
@@ -104,7 +104,7 @@ public class NewRevisionsEventServiceTest {
         ProjectChange mockProjectChange = mock(ProjectChange.class);
         when(projectChangeMapper.mapProjectChangeDocumentToProjectChange(any())).thenReturn(mockProjectChange);
 
-        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.empty(), 1, 1);
+        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.empty(), 1, 1, "");
 
         assertNotNull(result);
         assertEquals(1, result.getPageElements().size());
@@ -122,7 +122,7 @@ public class NewRevisionsEventServiceTest {
 
         when(repository.findAll(any(Example.class), eq(pageRequest))).thenReturn(mockPage);
 
-        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.empty(), 1, 1);
+        Page<ProjectChange> result = service.fetchPaginatedProjectChanges(projectId, Optional.empty(), 1, 1, "");
 
         assertNotNull(result);
         assertTrue(result.getPageElements().isEmpty());


### PR DESCRIPTION
Handles an extra filter field in the request to get the history for a project. This is implemented as a simple case insensitive contains search that could be evolved in the future to something more complex.