### PR TITLE
Replace the vanished openjdk:17 base image with eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jre
 MAINTAINER protege.stanford.edu
 
 EXPOSE 7761


### PR DESCRIPTION
Every image build fails with `openjdk:17: not found` — the deprecated openjdk tags have disappeared from Docker Hub. Temurin 17 is the successor base the other services already use. Unblocks the release of #35 (all 21 tests pass; only the docker build step fails).