### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>edu.stanford.protege</groupId>
 	<artifactId>webprotege-event-history-service</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<name>webprotege-event-history-service</name>
 	<description>Service that contains business specific events in order to be queried</description>
 	<properties>


### PR DESCRIPTION
Versions the event-sequencing release (#35, #36) so publishing does not overwrite the existing 2.0.0 image.