### PR TITLE
Make the publish workflow push the image the build already produces

### DIFF
--- a/.github/workflows/pub-docker-hub.yaml
+++ b/.github/workflows/pub-docker-hub.yaml
@@ -14,16 +14,16 @@ jobs:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
       - uses: actions/checkout@v3
-      - name: Set up Maven Central Repository
-        uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         with:
           java-version: '17'
-          distribution: 'adopt'
-          server-id: docker.io
-          server-username: DOCKER_USERNAME
-          server-password: DOCKER_PASSWORD
-      - name: Publish package
-        run: mvn --batch-mode -Prelease package dockerfile:push
-env:
-  DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
-  DOCKER_TOKEN: ${{secrets.DOCKER_PASSWORD}}
+          distribution: 'temurin'
+          cache: 'maven'
+      # The normal build already produces the image, tagged with the pom
+      # version, as part of `package`; publishing is just a push.
+      - name: Build the image
+        run: mvn --batch-mode -DskipTests package
+      - name: Push the image
+        run: |
+          VERSION=$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)
+          docker push "protegeproject/webprotege-event-history-service:${VERSION}"


### PR DESCRIPTION
Publishing a release ran `mvn -Prelease package dockerfile:push`, but the `dockerfile-maven-plugin` is no longer declared in the pom — so the 2.0.1 release (and anything since 2.0.0 on this lineage) fails with *No plugin found for prefix 'dockerfile'* before pushing anything. The regular `package` build already produces the image tagged with the pom version; the workflow now builds it and pushes that tag.